### PR TITLE
ShaderBytecode: Improve the generated assembly of OpCode::GetInfo.

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -378,8 +378,7 @@ struct OpCode {
     }
 
     const Info& GetInfo() const {
-        static const OpCode::Info unknown_instruction = { OpCode::Type::Unknown, 0, "UNK" };
-        static const OpCode::Info dummy = { OpCode::Type::Unknown, 0, "DMY" };
+        #define unknown_instruction { OpCode::Type::Unknown, 0, "UNK" }
         static const OpCode::Info info_table[] =  {
             { OpCode::Type::Arithmetic, OpCode::Info::TwoArguments, "add" },
             { OpCode::Type::Arithmetic, OpCode::Info::TwoArguments, "dp3" },
@@ -428,18 +427,26 @@ struct OpCode {
             { OpCode::Type::Conditional, OpCode::Info::JMPC, "jmpc" },
             { OpCode::Type::Conditional, OpCode::Info::JMPU, "jmpu" },
             { OpCode::Type::Arithmetic, OpCode::Info::Compare, "cmp" },
-            dummy,
+            { OpCode::Type::Arithmetic, OpCode::Info::Compare, "cmp" },
             { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
-            dummy,
-            dummy,
-            dummy,
-            dummy,
-            dummy,
-            dummy,
-            dummy,
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, OpCode::Info::SrcInversed, "madi" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
+            { OpCode::Type::MultiplyAdd, 0, "mad" },
             { OpCode::Type::MultiplyAdd, 0, "mad" }
         };
-        return info_table[(int)EffectiveOpCode()];
+        #undef unknown_instruction
+        return info_table[value];
     }
 
     operator Id() const {


### PR DESCRIPTION
Previous asm: https://gist.github.com/Subv/ea74f1b7f011838b0e08
New asm: https://gist.github.com/Subv/9cabcdda5f607d46edfd
That's ~98% reduction in code size, this function is now inlined by the MSVC compiler.
ref #15 