### PR TITLE
Remove exception from SwizzlePattern::DestComponentEnabled

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -731,9 +731,6 @@ union SwizzlePattern {
     }
 
     bool DestComponentEnabled(unsigned int i) const {
-        if (i >= 4)
-            throw std::out_of_range("index needs to be smaller than 4");
-
         return (dest_mask & (0x8 >> i));
     }
 


### PR DESCRIPTION
It served no purpose and was bloating the generated code size.
Previous ASM: https://gist.github.com/Subv/d1b4e98fa8dd5bd3aa62
New ASM: https://gist.github.com/Subv/ff1c1a469e863a232e96