### PR TITLE
include header for boost::fusion::swap

### DIFF
--- a/src/parser_assembly/flowcontrol.cpp
+++ b/src/parser_assembly/flowcontrol.cpp
@@ -30,6 +30,7 @@
 // #define BOOST_SPIRIT_DEBUG
 
 #include <boost/fusion/include/adapt_struct.hpp>
+#include <boost/fusion/include/swap.hpp>
 #include <boost/spirit/include/qi.hpp>
 
 #include "nihstro/parser_assembly.h"


### PR DESCRIPTION
required for building on boost 1.55.0 under debian