### PR TITLE
Fix compilation warnings

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <map>
 #include <stdexcept>
@@ -86,6 +87,10 @@ struct SourceRegister {
             return value - 0x10;
         else if (GetRegisterType() == RegisterType::FloatUniform)
             return value - 0x20;
+        else {
+            assert(false && "Unsupported register type given to nihstro::SourceRegister::GetIndex");
+            return -1; // Unreachable
+        }
     }
 
     static const SourceRegister FromTypeAndIndex(RegisterType type, int index) {
@@ -96,9 +101,9 @@ struct SourceRegister {
             reg.value = index + 0x10;
         else if (type == RegisterType::FloatUniform)
             reg.value = index + 0x20;
-        else {
-            // TODO: Should throw an exception or something.
-        }
+        else
+            assert(false && "Unsupported register type given to nihstro::SourceRegister::FromTypeAndIndex(");
+
         return reg;
     }
 
@@ -178,9 +183,9 @@ struct DestRegister {
             reg.value = index + 0x10;
         else if (type == RegisterType::FloatUniform) // TODO: Wait what? These shouldn't be writable..
             reg.value = index + 0x20;
-        else {
-            // TODO: Should throw an exception or something.
-        }
+        else
+            assert(false && "Unsupported register type given to nihstro::DestRegister::FromTypeAndIndex");
+
         return reg;
     }
 

--- a/include/nihstro/source_tree.h
+++ b/include/nihstro/source_tree.h
@@ -93,6 +93,16 @@ struct SourceTreeIterator {
 
     SourceTreeIterator(const SourceTreeIterator&) = default;
 
+    // In C++14, the default construtor will have to create an iterator that
+    // behaves like a past-the-end iterator of some unspecified empty container.
+    // In C++11, the compiler default is good enough.
+#if __cplusplus <= 201103L
+    SourceTreeIterator() = default;
+#else
+# warning "SourceTreeIterator is not compatible with C++ standard superior to C++11 yet"
+#endif
+
+
     SourceTreeIterator& operator += (difference_type n) {
         if (n > 0) {
             while (n) {

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -1242,6 +1242,9 @@ int main(int argc, char* argv[])
                         constant.b = (uint32_t)values[0] != 0;
                         break;
                     }
+
+                    default:
+                        break;
                 }
 
                 constant_table.push_back(constant);

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -1244,6 +1244,7 @@ int main(int argc, char* argv[])
                     }
 
                     default:
+                        throw "Constant registers can only be floats, ints or bools";
                         break;
                 }
 

--- a/src/parser_assembly/common.cpp
+++ b/src/parser_assembly/common.cpp
@@ -156,7 +156,7 @@ CommonRules<ParserIterator>::CommonRules(const ParserContext& context) {
         uint_after_sign = qi::uint_; // TODO: NOT dot (or alphanum) after this to prevent floats..., TODO: overflows?
         sign_with_uint = signs > uint_after_sign;
         index_expression_first_term = (qi::attr(+1) >> qi::uint_) | (peek_identifier > identifier);
-        index_expression_following_terms = (qi::lit('+') >> peek_identifier > identifier) | sign_with_uint;
+        index_expression_following_terms = ((qi::lit('+') >> peek_identifier) > identifier) | sign_with_uint;
         index_expression = (-index_expression_first_term)           // the first element has an optional sign
                             >> (*index_expression_following_terms); // following elements have a mandatory sign
 

--- a/src/parser_assembly/declaration.cpp
+++ b/src/parser_assembly/declaration.cpp
@@ -110,12 +110,12 @@ DeclarationParser<ParserIterator>::DeclarationParser(const ParserContext& contex
         // TODO: Would like to use +ascii::blank instead, but somehow that fails to parse lines like ".alias name o2.xy texcoord0" correctly
         string_as = qi::omit[qi::no_skip[*/*+*/ascii::blank >> qi::lit("as") >> +ascii::blank]];
 
-        declaration = ((qi::lit('.') > alias_identifier) >> identifier >> -(qi::lit('-') > identifier) >> -(qi::lit('.') > swizzle_mask))
+        declaration = (((qi::lit('.') > alias_identifier) >> identifier >> -(qi::lit('-') > identifier) >> -(qi::lit('.') > swizzle_mask))
                        >> (
                             (string_as > const_or_semantic)
                             | (dummy_const >> dummy_semantic)
                           )
-                       > end_of_statement;
+                      ) > end_of_statement;
 
         // Error handling
         output_semantics_rule.name("output semantic after \"as\"");

--- a/src/parser_assembly/floatop.cpp
+++ b/src/parser_assembly/floatop.cpp
@@ -79,7 +79,7 @@ FloatOpParser<ParserIterator>::FloatOpParser(const ParserContext& context)
         // chain of arguments for each group of opcodes
         expression_chain[0] = expression;
         for (int i = 1; i < 4; ++i) {
-            expression_chain[i] = expression_chain[i - 1] >> comma_rule > expression;
+            expression_chain[i] = (expression_chain[i - 1] >> comma_rule) > expression;
         }
 
         // e.g. "add o1, t2, t5"


### PR DESCRIPTION
This is part of my warning fixes for [citra](https://github.com/citra-emu/citra) :D.

I compiled with clang and fixed the warnings I got without adding any other compilation flag.

I also fixed https://github.com/neobrain/nihstro/issues/45 by adding the default implementation of the default constructor for SourceTreeIterator, it should be enough for C++11 but it will have to be modified a bit for C++14 (I added a comment mentioning this in the code and the commit message, see "Singular iterators" at http://en.cppreference.com/w/cpp/concept/ForwardIterator).
