### PR TITLE
Fix MAD/MADI encoding

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -543,7 +543,7 @@ union Instruction {
         BitField<0x07, 0x7, SourceRegister> src2i;
         BitField<0x0e, 0x5, SourceRegister> src1i;
 
-        // Address register value is used for relative addressing of src1
+        // Address register value is used for relative addressing of src1 / src2 (inverted)
         BitField<0x13, 0x2, uint32_t> address_register_index;
 
         union CompareOpType {  // TODO: Make nameless once MSVC supports it

--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -631,10 +631,20 @@ union Instruction {
 
         BitField<0x05, 0x5, SourceRegister> src3;
         BitField<0x0a, 0x7, SourceRegister> src2;
-        BitField<0x11, 0x7, SourceRegister> src1;
+        BitField<0x11, 0x5, SourceRegister> src1;
 
         BitField<0x05, 0x7, SourceRegister> src3i;
         BitField<0x0c, 0x5, SourceRegister> src2i;
+
+        // Address register value is used for relative addressing of src2 / src3 (inverted)
+        BitField<0x16, 0x2, uint32_t> address_register_index;
+
+        std::string AddressRegisterName() const {
+            if (address_register_index == 0) return "";
+            else if (address_register_index == 1) return "a0.x";
+            else if (address_register_index == 2) return "a0.y";
+            else /*if (address_register_index == 3)*/ return "aL";
+        }
 
         BitField<0x18, 0x5, DestRegister> dest;
     } mad;


### PR DESCRIPTION
MAD/MADI encoding is wrong in nihstro. I fixed this bug (https://github.com/citra-emu/citra/issues/974) in Citra but I don't have time to fix it in nihstro.

Basicly MAD encoding has an address offset for src2. ~~Not sure about MADI but I suspect the index would end up on src3 because having it on the MUL part is not too helpful.~~ Same offset-field is for src3 in MADI.

nihstro should still compile fine but there will be bugs with MAD and MADI unless the array offset is respected. ~~nihstro could probably be used to test the MADI encoding on actual hardware.~~

It's probably worth to mention that nihstro in its current form doesn't handle MAD and MADI properly anyway (arguments are not printed in disassembly for example).