### PR TITLE
Add missing 'pragma once'

### DIFF
--- a/include/nihstro/parser_shbin.h
+++ b/include/nihstro/parser_shbin.h
@@ -25,6 +25,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#pragma once
+
 #include <fstream>
 #include <map>
 #include <string>


### PR DESCRIPTION
Citra talking again.

There is no include guard or `#pragma once` in this file.

It's being included by code which uses Qt.
If more than one file includes "parser_shbin.h" automoc will then generate multiple includes in one file and things will go bad.
I do this in an experimental branch and therefore would like this fixed :)

(All other files in "\<nihstro\>/include/nihstro/" already contain `#pragma once`)