### PR TITLE
Fix the build with clang 3.8.

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -86,6 +86,7 @@ struct SourceRegister {
             return value - 0x10;
         else if (GetRegisterType() == RegisterType::FloatUniform)
             return value - 0x20;
+        throw "this should never be reached";
     }
 
     static const SourceRegister FromTypeAndIndex(RegisterType type, int index) {


### PR DESCRIPTION
Otherwise we fail with 'control reaches the end of a non-void
function'.

Not sure if `throw` is exactly the best solution, maybe we could return an error an propagate and or just emit a warning.
