### PR TITLE
Shader_bytecode, fix compilation warning on MSVC

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -761,7 +761,7 @@ union SwizzlePattern {
     }
 
     bool DestComponentEnabled(unsigned int i) const {
-        return (dest_mask & (0x8 >> i));
+        return (dest_mask & (0x8 >> i)) != 0;
     }
 
     void SetDestComponentEnabled(unsigned int i, bool enabled) {


### PR DESCRIPTION
Fix a stupid  warning "[by design](https://msdn.microsoft.com/en-us/library/b6801kcy.aspx)" on MSVC.