### PR TITLE
Fix comment parsing

### DIFF
--- a/include/nihstro/parser_assembly_private.h
+++ b/include/nihstro/parser_assembly_private.h
@@ -121,7 +121,7 @@ template<typename Iterator>
 struct AssemblySkipper : public qi::grammar<Iterator> {
 
     AssemblySkipper() : AssemblySkipper::base_type(skip) {
-        comments = qi::char_("//") >> *(qi::char_ - qi::eol);
+        comments = (qi::lit("//") | '#' | ';') >> *(qi::char_ - qi::eol);
 
         skip = +(comments | ascii::blank);
     }


### PR DESCRIPTION
`char_("//")` was just parsing a single `/` and the documented `#` and `;` didn't work